### PR TITLE
 Error in pexpect timeout

### DIFF
--- a/fat.py
+++ b/fat.py
@@ -79,7 +79,11 @@ def identify_arch(image_id):
     child.expect_exact(":")
     arch = child.readline().strip().decode("utf8")
     print ("[+] Architecture: " + arch)
-    child.expect_exact(pexpect.EOF)
+    try:
+        child.expect_exact(pexpect.EOF)
+    except Exception as e:
+        child.close(force=True)
+
     return arch
 
 


### PR DESCRIPTION
When I was testing the firmware file, I found that  when the architecture recognition was correctly recognized, but the program threw an exception at pexpect timeout. as follows：
```
Traceback (most recent call last):
  File "./fat.py", line 168, in <module>
    main()
  File "./fat.py", line 159, in main
    arch = identify_arch(image_id)
  File "./fat.py", line 82, in identify_arch
    child.expect_exact(pexpect.EOF)
  File "/usr/lib/python3/dist-packages/pexpect/__init__.py", line 1466, in expect_exact
    timeout, searchwindowsize)
  File "/usr/lib/python3/dist-packages/pexpect/__init__.py", line 1535, in expect_loop
    raise TIMEOUT(str(err) + '\n' + str(self))
pexpect.TIMEOUT: Timeout exceeded.
<pexpect.spawn object at 0x7fac57c2ac50>
```
So I think the code needs an exception catching. 