### PR TITLE
install dependencies required by firmadyne

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 sudo apt update
-sudo apt install -y python3-pip python3-pexpect unzip busybox-static fakeroot kpartx snmp uml-utilities util-linux vlan qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils
+sudo apt install -y python3-pip python3-pexpect unzip busybox-static fakeroot kpartx snmp uml-utilities util-linux vlan qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils lsb-core wget tar
 
 echo "Installing binwalk"
 git clone --depth=1 https://github.com/devttys0/binwalk.git


### PR DESCRIPTION
dependencies were discovered using a plain docker `ubuntu:18.04` docker image
requiring only `git` and `sudo` to setup everything.