### PR TITLE
Check whether lsb-core needs to be downloaded

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ set -e
 sudo apt update
 sudo apt install -y python3-pip python3-pexpect unzip busybox-static fakeroot kpartx snmp uml-utilities util-linux vlan qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils wget tar
 
-if [ ! -x $(which lsb_release) ]
+if [ ! -x "$(which lsb_release)" ]
 then
     sudo apt install -y lsb-core
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,12 @@
 
 set -e
 sudo apt update
-sudo apt install -y python3-pip python3-pexpect unzip busybox-static fakeroot kpartx snmp uml-utilities util-linux vlan qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils lsb-core wget tar
+sudo apt install -y python3-pip python3-pexpect unzip busybox-static fakeroot kpartx snmp uml-utilities util-linux vlan qemu-system-arm qemu-system-mips qemu-system-x86 qemu-utils wget tar
+
+if [ ! -x $(which lsb_release) ]
+then
+    sudo apt install -y lsb-core
+fi
 
 echo "Installing binwalk"
 git clone --depth=1 https://github.com/ReFirmLabs/binwalk.git


### PR DESCRIPTION
This removes lsb-core from the forcefully installed dependencies, since newer apt-based distros seem to have lsb-core removed. Since lsb_release is in the base OS anyway as far as I'm concerned, just check whether it's required or not.